### PR TITLE
Apply assorted ruff suggestions

### DIFF
--- a/python/populse_db/__init__.py
+++ b/python/populse_db/__init__.py
@@ -177,4 +177,4 @@ class Database:
 # Import here to allow the following import in external
 # modules:
 #   from populse_db import json_encode, json_decode
-from .database import json_encode, json_decode
+from .database import json_encode, json_decode  # noqa: E402

--- a/python/populse_db/database.py
+++ b/python/populse_db/database.py
@@ -144,19 +144,19 @@ class DatabaseSession:
     default_primary_key = 'primary_key'
     
     def execute(self, *args, **kwargs):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def commit(self):
-        raise NotImplemented()
+        raise NotImplementedError()
     
     def rollback(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def settings(self, category, key, default=None):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def set_settings(self, category, key, value):
-        raise NotImplemented()
+        raise NotImplementedError()
     
     def add_collection(self, name, primary_key=default_primary_key):
         """
@@ -170,7 +170,7 @@ class DatabaseSession:
                            - If the collection name is invalid
                            - If the primary_key is invalid
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def remove_collection(self, name):
         """
@@ -180,18 +180,18 @@ class DatabaseSession:
 
         :raise ValueError: If the collection does not exist
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def has_collection(self, name):
         """
         Check if a collection with the given name exists.
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __getitem__(self, collection_name):
         """Return a collection object given its name.
         """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def collections(self):
         """

--- a/python/populse_db/engine/sqlite.py
+++ b/python/populse_db/engine/sqlite.py
@@ -112,7 +112,7 @@ class SQLiteSession(DatabaseSession):
         Erase the whole database content.
         """
 
-        sql = f'SELECT name FROM sqlite_master'
+        sql = 'SELECT name FROM sqlite_master'
         tables = [i[0] for i in self.execute(sql)]
         for table in tables:
             sql = f'DROP TABLE {table}'
@@ -139,7 +139,7 @@ class SQLiteSession(DatabaseSession):
         self._collection_cache.pop(name, None)
     
     def __iter__(self):
-        sql = f"SELECT name FROM sqlite_master WHERE type='table'"
+        sql = "SELECT name FROM sqlite_master WHERE type='table'"
         for row in self.execute(sql):
             table = row[0]
             if table == self.populse_db_table:

--- a/python/populse_db/test.py
+++ b/python/populse_db/test.py
@@ -1,7 +1,5 @@
-from dataclasses import replace
 from datetime import datetime, date, time
 import os
-from pydoc import doc
 import shutil
 import tempfile
 import unittest
@@ -1140,19 +1138,19 @@ def create_test_case(**database_creation_parameters):
 
                 files = ('abc', 'bcd', 'def', 'xyz')
                 for file in files:
-                    for date in list_datetime:
+                    for dt in list_datetime:
                         for format, ext in (('NIFTI', 'nii'),
                                             ('DICOM', 'dcm'),
                                             ('Freesurfer', 'mgz')):
                             document = dict(
-                                name='/%s_%d.%s' % (file, date.year, ext),
+                                name='/%s_%d.%s' % (file, dt.year, ext),
                                 format=format,
                                 strings=list(file),
-                                datetime=date,
+                                datetime=dt,
                                 has_format=True,
                             )
                             session.add_document("collection1", document)
-                        document = '/%s_%d.none' % (file, date.year)
+                        document = '/%s_%d.none' % (file, dt.year)
                         d = dict(name=document, strings=list(file))
                         session.add_document("collection1", d)
 
@@ -1737,8 +1735,8 @@ def create_test_case(**database_creation_parameters):
                 'FALSE': False,
                 'false': False,
                 'Null': None,
+                'NULL': None,
                 'null': None,
-                'Null': None,
                 '0': 0,
                 '123456789101112': 123456789101112,
                 '-45': -45,


### PR DESCRIPTION
This will help add flake8 to pre-commit.
```
F401 [*] `dataclasses.replace` imported but unused
F401 [*] `pydoc.doc` imported but unused
F402 Import `date` from line 1 shadowed by loop variable
F541 [*] f-string without any placeholders
F601 Dictionary key literal `'Null'` repeated
F901 [*] `raise NotImplemented` should be `raise NotImplementedError`
```
