### PR TITLE
Move options from `.pre-commit-config.yaml` to `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     rev: 23.11.0
     hooks:
       - id: black
-        exclude: '^docs/'
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+select = ["E", "F", "I", "UP", "W"]
+ignore = ["E501"] # do not complain about long documentation lines
+
+[tool.ruff.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.black]
+force-exclude = "docs"
+
 [tool.ruff]
 select = ["E", "F", "I", "UP", "W"]
 ignore = ["E501"] # do not complain about long documentation lines


### PR DESCRIPTION
This way, black will use the same options when it is run from pre-commit or directly as a standalone command.