### PR TITLE
Use the ruff formatter, instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,9 @@ repos:
     -   id: fix-byte-order-marker
     -   id: trailing-whitespace
 
--   repo: https://github.com/psf/black
-    rev: 23.11.0
-    hooks:
-      - id: black
-        exclude: '^docs/'
-
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.5
+    rev: v0.1.7
     hooks:
     -   id: ruff
+    -   id: ruff-format
+        exclude: '^docs/'

--- a/python/populse_db/__init__.py
+++ b/python/populse_db/__init__.py
@@ -170,5 +170,5 @@ class Database:
 
 # Import here to allow the following import in external
 # modules:
-from .database import json_encode, json_decode  # noqa: F401, E402
+from .database import json_decode, json_encode  # noqa: F401, E402
 from .storage import Storage  # noqa: F401, E402

--- a/python/populse_db/engine/sqlite.py
+++ b/python/populse_db/engine/sqlite.py
@@ -1,8 +1,8 @@
-from datetime import date, datetime, time
-import dateutil
 import json
 import sqlite3
+from datetime import date, datetime, time
 
+import dateutil
 
 from ..database import (
     DatabaseCollection,

--- a/python/populse_db/storage.py
+++ b/python/populse_db/storage.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+
 from .database import type_to_str
 from .storage_server import StorageServer
 

--- a/python/populse_db/storage_server.py
+++ b/python/populse_db/storage_server.py
@@ -1,6 +1,8 @@
 from uuid import uuid4
-from . import Database
+
 from populse_db.database import str_to_type
+
+from . import Database
 
 
 class StorageServer:

--- a/python/populse_db/test/__main__.py
+++ b/python/populse_db/test/__main__.py
@@ -1,8 +1,8 @@
 import argparse
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 parser = argparse.ArgumentParser(
     prog="Test populse_db module", description="Run populse_db test suite"
@@ -66,10 +66,10 @@ if args.html:
     pytest_command += ["--cov=populse_db", f"--html={args.html}/tests.html"]
     coverage_command = [sys.executable, "-m", "coverage", "html", "-d", args.html]
     env = os.environ.copy()
-    print(" ".join("'{}'".format(i) for i in pytest_command))
+    print(" ".join(f"'{i}'" for i in pytest_command))
     subprocess.check_call(pytest_command, env=env, cwd=module_src)
-    print(" ".join("'{}'".format(i) for i in coverage_command))
+    print(" ".join(f"'{i}'" for i in coverage_command))
     subprocess.check_call(coverage_command, cwd=module_src)
 else:
-    print(" ".join("'{}'".format(i) for i in pytest_command))
+    print(" ".join(f"'{i}'" for i in pytest_command))
     subprocess.check_call(pytest_command, cwd=module_src)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,21 @@
+[lint]
+extend-ignore = [
+  # https://docs.astral.sh/ruff/rules/redundant-open-modes/
+  # we prefer explicit to implicit open modes
+  "UP015",
+  # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "W191",
+  "E111",
+  "E114",
+  "E117",
+  "D206",
+  "D300",
+  "Q000",
+  "Q001",
+  "Q002",
+  "Q003",
+  "COM812",
+  "COM819",
+  "ISC001",
+  "ISC002",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,8 @@
 [lint]
+extend-select = [
+  "I",   # https://docs.astral.sh/ruff/rules/#isort-i
+  "UP",  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+]
 extend-ignore = [
   # https://docs.astral.sh/ruff/rules/redundant-open-modes/
   # we prefer explicit to implicit open modes


### PR DESCRIPTION
The ruff formatter seems to gain traction. Replacing [black](https://github.com/psf/black) with [ruff](https://github.com/astral-sh/ruff) means one less tool to depend on.

I have based this commit on:
- ruff-pre-commit [README.md](https://github.com/astral-sh/ruff-pre-commit/blob/main/README.md) | Using Ruff with pre-commit
- The Ruff Formatter | [Conflicting lint rules](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules)

Overrides https://github.com/populse/populse_db/pull/75.