### PR TITLE
Fix error in AppVeyor CI jobs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
   - python -m pip install pip --upgrade
   - pip -V
   - pip install setuptools --upgrade
+  - pip install pytest
   - pip install -e .[postgres]
   - pip install codecov
 


### PR DESCRIPTION
	No module named pytest

The remaining errors need to be fixed separately in the source code.