### PR TITLE
Fix ruff/flake8-bugbear issues

### DIFF
--- a/python/populse_db/storage.py
+++ b/python/populse_db/storage.py
@@ -193,10 +193,10 @@ class SchemaSession:
 
 
 class StorageSession:
-    def __init__(self, server, connection_id, path=[]):
+    def __init__(self, server, connection_id, path=None):
         super().__setattr__("_server", server)
         super().__setattr__("_connection_id", connection_id)
-        super().__setattr__("_path", path)
+        super().__setattr__("_path", path or [])
 
     def __getitem__(self, key):
         return self.__class__(self._server, self._connection_id, self._path + [key])

--- a/python/populse_db/test/test_base.py
+++ b/python/populse_db/test/test_base.py
@@ -1926,7 +1926,8 @@ def create_test_case(**database_creation_parameters):
                 with database as session:
                     session.add_collection("collection1", "name")
                     session.add_document("collection1", {"name": "toto"})
-                    boom  # Raises an exception, modifications are rolled back
+                    # Raise an exception to roll back modifications
+                    boom  # noqa: B018
             except NameError:
                 pass
 

--- a/python/populse_db/test/test_base.py
+++ b/python/populse_db/test/test_base.py
@@ -84,13 +84,13 @@ def create_test_case(**database_creation_parameters):
                 if self.database_creation_parameters["database_url"].startswith(
                     "postgresql"
                 ):
-                    raise unittest.SkipTest(str(e))
+                    raise unittest.SkipTest(str(e)) from e
                 raise
             except ImportError as e:
                 if "psycopg2" in str(e) and self.database_creation_parameters[
                     "database_url"
                 ].startswith("postgresql"):
-                    raise unittest.SkipTest(str(e))
+                    raise unittest.SkipTest(str(e)) from e
                 raise
             if clear:
                 with db as dbs:

--- a/python/populse_db/test/test_storage.py
+++ b/python/populse_db/test/test_storage.py
@@ -196,9 +196,10 @@ def test_storage():
         } == snapshots[0]
 
         # Select one document field from a collection
-        d.snapshots["0001292COG", "M0", "greywhite"].image.get() == snapshots[0][
-            "image"
-        ]
+        assert (
+            d.snapshots["0001292COG", "M0", "greywhite"].image.get()
+            == snapshots[0]["image"]
+        )
 
         # Select all documents from a collection (ignore fields with None value)
         assert [


### PR DESCRIPTION
Except B017. Defer to later:
* B017 →#88

Required by #90 to select ruff [flake8-bugbear (B)](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b) rules as suggested by repo-review:
https://learn.scientific-python.org/development/guides/repo-review/?repo=populse%2Fpopulse_db&branch=3.0